### PR TITLE
when using abspath, the path gets doubled up on files.src

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "vulcanize": "^1.8.1",
+    "vulcanize": "jasongardnerlv/vulcanize",
     "node-fs": "~0.1.7"
   },
   "devDependencies": {

--- a/tasks/vulcanize.js
+++ b/tasks/vulcanize.js
@@ -50,6 +50,13 @@ module.exports = function(grunt) {
         }
       });
 
+      //if abspath was set, strip it from the src file path, lest it get applied twice
+      if (typeof options.abspath !== 'undefined' && options.abspath.length > 0) {
+        if (src[0].indexOf(options.abspath) === 0) {
+          src[0] = src[0].substr(options.abspath.length);
+        }
+      }
+
       // Handle options.
       options.output = f.dest;
 


### PR DESCRIPTION
My project has the grunt file in the root, and a 'src' subfolder.  My previous grunt config for grunt-vulcanize has the abspath set to 'src/', and the files set to '<%= build_dist %>/vulcanized.html': 'src/vulcanize/elements.html', and that worked fine before.  I switched to this fork, as I port my project to 1.0 (thanks for this work!), but these configs no longer worked.  I need to keep abspath set, so that everything will resolve as it walks my imports, but what was happening was the file src (src/vulcanize/elements.html) was ending up 'src/src/vulcanize/elements.html' once it hit the vulcanize library, which then died.  This small change resolved it for me.
